### PR TITLE
Add pygame submodule

### DIFF
--- a/org.sugarlabs.BaseApp.json
+++ b/org.sugarlabs.BaseApp.json
@@ -19,6 +19,7 @@
     "modules": [
         "shared-modules/dbus-glib/dbus-glib-0.110.json",
         "shared-modules/intltool/intltool-0.51.json",
+        "shared-modules/pygame/pygame-1.9.6.json",
         {
             "name": "empy",
             "cleanup": [ "*" ],


### PR DESCRIPTION
When trying to build an activity that uses pygame, I'd included
pygame as one of the modules but after running

`SUGAR_BUNDLE_ID=org.sugarlabs.stickhero SUGAR_BUNDLE_PATH=$PWD sugarapp`

from org.sugarlabs.BaseApp dev environment I get this error;

```python
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/sugarapp/application.py", line 58, in do_activate
    self._activity = self._setup_activity()
  File "/app/lib/python3.8/site-packages/sugarapp/application.py", line 121, in _setup_activity
    module = __import__(module_name)
  File "/home/ibiam/flatpak-apps/stick-hero-activity/activity.py", line 7, in <module>
    import sugargame.canvas
  File "/home/ibiam/flatpak-apps/stick-hero-activity/sugargame/canvas.py", line 27, in <module>
    import pygame
ModuleNotFoundError: No module named 'pygame'
```

And it doesn't make any sense as pygame is packaged with the flatpak app,
this PR aims to package pygame with org.sugarlabs.BaseApp as I believe this
would fix the issue.

@tchx84 kindly review.